### PR TITLE
Throw real Errors instead of strings and plain objects

### DIFF
--- a/lib/avltree.js
+++ b/lib/avltree.js
@@ -63,14 +63,14 @@ _AVLTree.prototype.checkHeightCorrect = function () {
 
   if (!this.hasOwnProperty('key')) { return; }   // Empty tree
 
-  if (this.left && this.left.height === undefined) { throw "Undefined height for node " + this.left.key; }
-  if (this.right && this.right.height === undefined) { throw "Undefined height for node " + this.right.key; }
-  if (this.height === undefined) { throw "Undefined height for node " + this.key; }
+  if (this.left && this.left.height === undefined) { throw new Error("Undefined height for node " + this.left.key); }
+  if (this.right && this.right.height === undefined) { throw new Error("Undefined height for node " + this.right.key); }
+  if (this.height === undefined) { throw new Error("Undefined height for node " + this.key); }
 
   leftH = this.left ? this.left.height : 0;
   rightH = this.right ? this.right.height : 0;
 
-  if (this.height !== 1 + Math.max(leftH, rightH)) { throw "Height constraint failed for node " + this.key; }
+  if (this.height !== 1 + Math.max(leftH, rightH)) { throw new Error("Height constraint failed for node " + this.key); }
   if (this.left) { this.left.checkHeightCorrect(); }
   if (this.right) { this.right.checkHeightCorrect(); }
 };
@@ -91,7 +91,7 @@ _AVLTree.prototype.balanceFactor = function () {
  * Check that the balance factors are all between -1 and 1
  */
 _AVLTree.prototype.checkBalanceFactors = function () {
-  if (Math.abs(this.balanceFactor()) > 1) { throw 'Tree is unbalanced at node ' + this.key; }
+  if (Math.abs(this.balanceFactor()) > 1) { throw new Error('Tree is unbalanced at node ' + this.key); }
 
   if (this.left) { this.left.checkBalanceFactors(); }
   if (this.right) { this.right.checkBalanceFactors(); }
@@ -270,10 +270,10 @@ _AVLTree.prototype.insert = function (key, value) {
     // Same key: no change in the tree structure
     if (currentNode.compareKeys(currentNode.key, key) === 0) {
       if (currentNode.unique) {
-        throw { message: "Can't insert key " + key + ", it violates the unique constraint"
-              , key: key
-              , errorType: 'uniqueViolated'
-              };
+        var err = new Error("Can't insert key " + key + ", it violates the unique constraint");
+        err.key = key;
+        err.errorType = 'uniqueViolated';
+        throw err;
       } else {
         currentNode.data.push(value);
       }

--- a/lib/bst.js
+++ b/lib/bst.js
@@ -97,7 +97,7 @@ BinarySearchTree.prototype.checkNodeOrdering = function () {
   if (this.left) {
     this.left.checkAllNodesFullfillCondition(function (k) {
       if (self.compareKeys(k, self.key) >= 0) {
-        throw 'Tree with root ' + self.key + ' is not a binary search tree';
+        throw new Error('Tree with root ' + self.key + ' is not a binary search tree');
       }
     });
     this.left.checkNodeOrdering();
@@ -106,7 +106,7 @@ BinarySearchTree.prototype.checkNodeOrdering = function () {
   if (this.right) {
     this.right.checkAllNodesFullfillCondition(function (k) {
       if (self.compareKeys(k, self.key) <= 0) {
-        throw 'Tree with root ' + self.key + ' is not a binary search tree';
+        throw new Error('Tree with root ' + self.key + ' is not a binary search tree');
       }
     });
     this.right.checkNodeOrdering();
@@ -119,12 +119,12 @@ BinarySearchTree.prototype.checkNodeOrdering = function () {
  */
 BinarySearchTree.prototype.checkInternalPointers = function () {
   if (this.left) {
-    if (this.left.parent !== this) { throw 'Parent pointer broken for key ' + this.key; }
+    if (this.left.parent !== this) { throw new Error('Parent pointer broken for key ' + this.key); }
     this.left.checkInternalPointers();
   }
 
   if (this.right) {
-    if (this.right.parent !== this) { throw 'Parent pointer broken for key ' + this.key; }
+    if (this.right.parent !== this) { throw new Error('Parent pointer broken for key ' + this.key); }
     this.right.checkInternalPointers();
   }
 };
@@ -136,7 +136,7 @@ BinarySearchTree.prototype.checkInternalPointers = function () {
 BinarySearchTree.prototype.checkIsBST = function () {
   this.checkNodeOrdering();
   this.checkInternalPointers();
-  if (this.parent) { throw "The root shouldn't have a parent"; }
+  if (this.parent) { throw new Error("The root shouldn't have a parent"); }
 };
 
 
@@ -214,10 +214,10 @@ BinarySearchTree.prototype.insert = function (key, value) {
   // Same key as root
   if (this.compareKeys(this.key, key) === 0) {
     if (this.unique) {
-      throw { message: "Can't insert key " + key + ", it violates the unique constraint"
-            , key: key
-            , errorType: 'uniqueViolated'
-            };
+      var err = new Error("Can't insert key " + key + ", it violates the unique constraint");
+      err.key = key;
+      err.errorType = 'uniqueViolated';
+      throw err;
     } else {
       this.data.push(value);
     }

--- a/lib/customUtils.js
+++ b/lib/customUtils.js
@@ -24,7 +24,10 @@ function defaultCompareKeysFunction (a, b) {
   if (a > b) { return 1; }
   if (a === b) { return 0; }
 
-  throw { message: "Couldn't compare elements", a: a, b: b };
+  var err = new Error("Couldn't compare elements");
+  err.a = a;
+  err.b = b;
+  throw err;
 }
 module.exports.defaultCompareKeysFunction = defaultCompareKeysFunction;
 


### PR DESCRIPTION
Many good reasons to throw actual `Error` object instances instead of strings and plain objects.  For example:
 - Consumers can more accurately detect the error (and its specific type, potentially) by using the `instanceof` operator/keyword.
 - Consumers can expect to consistently operate on the object as they would for any other `Error` object (e.g. it will have a `message` property, a `name` property, etc.).  If they tried to use `err.message` on your string-based `throw`-n objects, they would end up with `undefined`.
 - Consumers can access the `err.stack` information for better debugging and root cause analysis.

More info:
 - https://www.nczonline.net/blog/2009/03/10/the-art-of-throwing-javascript-errors-part-2/

Related:
 - https://github.com/louischatriot/nedb/pull/341