### PR TITLE
Method #keysBetweenBounds to search for keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ bst.search(1);    // Equal to []
 // Note the difference between $lt (less than) and $gte (less than OR EQUAL)
 bst.betweenBounds({ $lt: 18, $gte: 12});   // Equal to ['something else', 'some data for key 15']
 
+// Retrieve keys between bounds, sorted as well
+bst.keysBetweenBounds({ $lt: 18, $gte: 12});   // Equal to [12, 15]
+
 // Deleting all the data relating to a key
 bst.delete(15);   // bst.search(15) will now give []
 bst.delete(18, 'world');   // bst.search(18) will now give ['hello']

--- a/lib/bst.js
+++ b/lib/bst.js
@@ -361,6 +361,29 @@ BinarySearchTree.prototype.betweenBounds = function (query, lbm, ubm) {
 
 
 /**
+ * Get all the keys between bounds. Return them in key order
+ * This method is useful for creating suggestions for search terms and faceted search.
+ *
+ * @param {Object} query Mongo-style query where keys are $lt, $lte, $gt or $gte (other keys are not considered)
+ * @param {Functions} lbm/ubm matching functions calculated at the first recursive step
+ */
+BinarySearchTree.prototype.keysBetweenBounds = function (query, lbm, ubm) {
+  var res = [];
+
+  if (!this.hasOwnProperty('key')) { return []; }   // Empty tree
+
+  lbm = lbm || this.getLowerBoundMatcher(query);
+  ubm = ubm || this.getUpperBoundMatcher(query);
+
+  if (lbm(this.key) && this.left) { append(res, this.left.keysBetweenBounds(query, lbm, ubm)); }
+  if (lbm(this.key) && ubm(this.key)) { res.push(this.key); }
+  if (ubm(this.key) && this.right) { append(res, this.right.keysBetweenBounds(query, lbm, ubm)); }
+
+  return res;
+};
+
+
+/**
  * Delete the current node if it is a leaf
  * Return true if it was deleted
  */

--- a/test/bst.test.js
+++ b/test/bst.test.js
@@ -450,6 +450,44 @@ describe('Binary search tree', function () {
       assert.deepEqual(bst.betweenBounds({ $lte: 9 }), ['data 3', 'data 5', 'data 8']);
     });
 
+    it('Can search for keys between two bounds', function () {
+      var bst = new BinarySearchTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        bst.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(bst.keysBetweenBounds({ $gte: 8, $lte: 15 }), [8, 10, 13, 15]);
+      assert.deepEqual(bst.keysBetweenBounds({ $gt: 8, $lt: 15 }), [10, 13]);
+    });
+
+    it('Bounded search for keys can handle cases where query contains both $lt and $lte, or both $gt and $gte', function () {
+      var bst = new BinarySearchTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        bst.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(bst.keysBetweenBounds({ $gt:8, $gte: 8, $lte: 15 }), [10, 13, 15]);
+      assert.deepEqual(bst.keysBetweenBounds({ $gt:5, $gte: 8, $lte: 15 }), [8, 10, 13, 15]);
+      assert.deepEqual(bst.keysBetweenBounds({ $gt:8, $gte: 5, $lte: 15 }), [10, 13, 15]);
+
+      assert.deepEqual(bst.keysBetweenBounds({ $gte: 8, $lte: 15, $lt: 15 }), [8, 10, 13]);
+      assert.deepEqual(bst.keysBetweenBounds({ $gte: 8, $lte: 18, $lt: 15 }), [8, 10, 13]);
+      assert.deepEqual(bst.keysBetweenBounds({ $gte: 8, $lte: 15, $lt: 18 }), [8, 10, 13, 15]);
+    });
+
+    it('Bounded search can work when one or both boundaries are missing', function () {
+      var bst = new BinarySearchTree();
+
+      [10, 5, 15, 3, 8, 13, 18].forEach(function (k) {
+        bst.insert(k, 'data ' + k);
+      });
+
+      assert.deepEqual(bst.keysBetweenBounds({ $gte: 11 }), [13, 15, 18]);
+      assert.deepEqual(bst.keysBetweenBounds({ $lte: 9 }), [3, 5, 8]);
+    });
+
   });   /// ==== End of 'Search' ==== //
 
 


### PR DESCRIPTION
I would like to implement an autosuggest for search-terms (with nedb). It would be helpful to be able to iterate the indices of the database, since they contain all the necessary information.

This PR is the first step towards this goal. It adds a method #keyBetweenBounds, which works just like #betweenBounds, but returns the keys instead of the data. 

The implementation is mostly a copy of #betweenBounds with adapted recursive calls. This could probably be refactored for code-reuse among the two methods, but I think this will make the code more complicated to read and probably less efficient. It there is a third method of this kind, it might make sense.

Let me know what you think of it.

